### PR TITLE
Allow for non-Integer values in column definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,17 @@ column :first_name, 0 do |value|
 end
 ```
 
+Pass in non-Integer parameters to the column macro and these are made available to the block without any processing.
+
+``` ruby
+attr_accessor :tenant_id
+
+column :first_name, 0, { tenant_id: tenant_id} do |value|
+  result = values[0].upcase
+  result << Tenant.find(id: values[1]).name
+end
+```
+
 ### Virtual Columns
 
 Virtual columns are not sourced from input. Omit the index to create a virtual column. Like real columns, virtual columns are included in the conformed output.

--- a/lib/conformist/column.rb
+++ b/lib/conformist/column.rb
@@ -1,21 +1,25 @@
 module Conformist
   class Column
-    attr_accessor :name, :indexes, :preprocessor
+    attr_accessor :name, :attrs, :preprocessor
 
-    def initialize name, *indexes, &preprocessor
+    def initialize name, *attrs, &preprocessor
       self.name         = name
-      self.indexes      = indexes
+      self.attrs        = attrs
       self.preprocessor = preprocessor
     end
 
     def values_in enumerable
-      values = Array(enumerable).values_at(*indexes).map do |value|
+      column_indexes = []
+      raw_attrs = []
+      self.attrs.each { |i| i.is_a?(Integer) ? column_indexes << i : raw_attrs << i }
+      values = Array(enumerable).values_at(*column_indexes).map do |value|
         if value.respond_to? :strip
           value.strip
         else
           value
         end
       end
+      values += raw_attrs if raw_attrs.any?
       values = values.first if values.size == 1
       if preprocessor
         preprocessor.call values

--- a/test/schemas/relation_lookup.rb
+++ b/test/schemas/relation_lookup.rb
@@ -1,0 +1,7 @@
+class RelationLookup
+  extend Conformist
+
+  column :name, 0, 1, { agent_id: '007' } do |values|
+    "#{values[0]}, #{values[1]}, (observed by #{values[2][:agent_id]})"
+  end
+end

--- a/test/unit/conformist/schema_test.rb
+++ b/test/unit/conformist/schema_test.rb
@@ -49,7 +49,7 @@ class Conformist::SchemaTest < MiniTest::Unit::TestCase
     definition = Class.new { extend Schema }
     definition.column :a
     definition.column :b
-    assert_equal [0, 1], definition.columns.map { |column| column.indexes }.flatten
+    assert_equal [0, 1], definition.columns.map { |column| column.attrs }.flatten
   end
 
   def test_conform_returns_enumerable

--- a/test/unit/integration_test.rb
+++ b/test/unit/integration_test.rb
@@ -3,6 +3,7 @@ require 'helper'
 require 'schemas/acma'
 require 'schemas/citizens'
 require 'schemas/fcc'
+require 'schemas/relation_lookup'
 require 'spreadsheet'
 
 class IntegrationTest < MiniTest::Unit::TestCase
@@ -81,12 +82,18 @@ class IntegrationTest < MiniTest::Unit::TestCase
       column :capital, 2
     end
     child = Conformist.new parent do
-      column :country do 
+      column :country do
         'Australia'
       end
     end
     enumerable = child.conform data
     last = enumerable.to_a.last
     assert_equal HashStruct.new(:state => 'QLD, Queensland', :capital => 'Brisbane', :country => 'Australia'), last
+  end
+
+  def test_instance_with_additional_attrs_for_preprocessor
+    enumerable = RelationLookup.conform open_csv('citizens.csv'), :skip_first => true
+    first = enumerable.to_a.first
+    assert_equal HashStruct.new(:name => 'Aaron, 21, (observed by 007)'), first
   end
 end


### PR DESCRIPTION
In my use case I need that feature to pass in a tenant_id to the preprocessor block so that I can do a scoped db lookup  inside the preprocessor
