### PR TITLE
Allow string column indexes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,20 @@ the first row is the header row and irrelevant for enumeration.
 schema.conform CSV.open('~/file_with_headers.csv'), :skip_first => true
 ```
 
+#### Named Columns
+
+Strings can be used as column indexes instead of integers. These strings will be matched
+against the first row to determine the appropriate numerical index.
+
+``` ruby
+citizen = Conformist.new do
+  column :email, 'EM'
+  column :name, 'FN', 'LN'
+end
+
+citizen.conform [['FN', 'LN', 'EM'], ['Tate', 'Johnson', 'tate@tatey.com']], :skip_first => true
+```
+
 #### Enumerator
 
 `#conform` is lazy, returning an [Enumerator](http://www.ruby-doc.org/core-1.9.3/Enumerator.html). Input is not parsed until you call `#each`, `#map` or any method defined in [Enumerable](http://www.ruby-doc.org/core-1.9.3/Enumerable.html). That means schemas can be assigned now and evaluated later. `#each` has the lowest memory footprint because it does not build a collection.

--- a/lib/conformist/column.rb
+++ b/lib/conformist/column.rb
@@ -1,11 +1,24 @@
 module Conformist
   class Column
-    attr_accessor :name, :indexes, :preprocessor
+    attr_accessor :name, :sources, :indexes, :preprocessor
 
-    def initialize name, *indexes, &preprocessor
+    def initialize name, *sources, &preprocessor
       self.name         = name
-      self.indexes      = indexes
+      self.sources      = sources
+      self.indexes      = sources
       self.preprocessor = preprocessor
+    end
+
+    def calculate_indices!(headers)
+      headers = Array(headers).collect {|header| header.to_s.downcase.squeeze.strip }
+
+      self.indexes = sources.collect do |source|
+        if source.is_a?(String)
+          headers.index(source.downcase)
+        else
+          source
+        end
+      end.compact
     end
 
     def values_in enumerable

--- a/lib/conformist/schema.rb
+++ b/lib/conformist/schema.rb
@@ -1,4 +1,4 @@
-module Conformist  
+module Conformist
   module Schema
     def self.included base
       base.send :include, InstanceExtensions
@@ -24,7 +24,7 @@ module Conformist
           self.columns = super_schema.columns.dup
         end
         if block
-          instance_eval &block 
+          instance_eval &block
         end
       end
     end
@@ -53,9 +53,14 @@ module Conformist
 
       def conform enumerables, options = {}
         options = options.dup
+
         Enumerator.new do |yielder|
           enumerables.each do |enumerable|
-            next if options.delete :skip_first
+            if options.delete :skip_first
+              columns.each {|column| column.calculate_indices!(enumerable) }
+              next
+            end
+
             yielder.yield builder.call(self, enumerable)
           end
         end

--- a/test/unit/integration_test.rb
+++ b/test/unit/integration_test.rb
@@ -81,12 +81,23 @@ class IntegrationTest < Minitest::Test
       column :capital, 2
     end
     child = Conformist.new parent do
-      column :country do 
+      column :country do
         'Australia'
       end
     end
     enumerable = child.conform data
     last = enumerable.to_a.last
     assert_equal HashStruct.new(:state => 'QLD, Queensland', :capital => 'Brisbane', :country => 'Australia'), last
+  end
+
+  def test_named_columns
+    schema = Conformist.new do
+      column :name, 'Name'
+      column :age, 'Age'
+      column :gender, 'Gender'
+    end
+    enumerable = schema.conform open_csv('citizens.csv'), :skip_first => true
+    first      = enumerable.to_a.first
+    assert_equal HashStruct.new(:name => 'Aaron', :age => '21', :gender => 'Male'), first
   end
 end


### PR DESCRIPTION
I added the ability to specify strings for column indexes which are matched against the header row during the conform method. Hope someone finds this useful :). I'd like to get this merged if possible. Please let me know if you have any feedback.