### PR TITLE
Don't squeeze before matching headers.

### DIFF
--- a/lib/conformist/column.rb
+++ b/lib/conformist/column.rb
@@ -10,7 +10,7 @@ module Conformist
     end
 
     def calculate_indices!(headers)
-      headers = Array(headers).collect {|header| header.to_s.downcase.squeeze.strip }
+      headers = Array(headers).collect {|header| header.to_s.downcase }
 
       self.indexes = sources.collect do |source|
         if source.is_a?(String)


### PR DESCRIPTION
Hi @tatey,

I've realized (after much hair pulling) my pull request (#8) has a stupid bug.

Squeeze without any arguments actually throws away ANY repeated letters, not just spaces. So "Submitter" is squeezed to "Submiter" before attempting to match. This is clearly not what we want. I've come to the conclusion it would be better to remove both the squeeze and the strip to avoid as much magic as possible. You can always squeeze and strip the headers externally if needed.

Sorry about introducing this bug.