### PR TITLE
Always return nil when named column isn't found.

### DIFF
--- a/lib/conformist/column.rb
+++ b/lib/conformist/column.rb
@@ -18,11 +18,15 @@ module Conformist
         else
           source
         end
-      end.compact
+      end
     end
 
     def values_in enumerable
-      values = Array(enumerable).values_at(*indexes).map do |value|
+      enumerable = Array(enumerable)
+
+      values = Array(indexes).map do |index|
+        value = enumerable.at(index) if index
+
         if value.respond_to? :strip
           value.strip
         else

--- a/test/unit/integration_test.rb
+++ b/test/unit/integration_test.rb
@@ -100,4 +100,13 @@ class IntegrationTest < Minitest::Test
     first      = enumerable.to_a.first
     assert_equal HashStruct.new(:name => 'Aaron', :age => '21', :gender => 'Male'), first
   end
+
+  def test_missing_named_column
+    schema = Conformist.new do
+      column :state, 'State'
+    end
+    enumerable = schema.conform open_csv('citizens.csv'), :skip_first => true
+    first      = enumerable.to_a.first
+    assert_equal HashStruct.new(:state => nil), first
+  end
 end


### PR DESCRIPTION
This improves named column support so that it acts predictably (returns a nil value for all rows) if the named column isn't found.