### PR TITLE
Speed up building HashStruct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ rvm:
   - 2.2.0
   - 2.3.1
   - jruby
+
+before_install:
+  - gem install bundler -v ">= 1.8.9"

--- a/lib/conformist/builder.rb
+++ b/lib/conformist/builder.rb
@@ -2,9 +2,10 @@ module Conformist
   class Builder
     def self.call schema, enumerable
       columns = schema.columns
-      columns.inject HashStruct.new do |hash, column|
-        hash.merge column.name => column.values_in(enumerable)
+      hash = columns.each_with_object({}) do |column, hash|
+        hash[column.name] = column.values_in(enumerable)
       end
+      HashStruct.new hash
     end
   end
 end

--- a/lib/conformist/hash_struct.rb
+++ b/lib/conformist/hash_struct.rb
@@ -10,12 +10,6 @@ module Conformist
       self.attributes = attributes
     end
 
-    def merge other
-      self.class.new.tap do |instance|
-        instance.attributes = attributes.merge other
-      end
-    end
-
     def == other
       other.class == self.class && attributes == other.attributes
     end

--- a/test/unit/conformist/hash_struct_test.rb
+++ b/test/unit/conformist/hash_struct_test.rb
@@ -24,14 +24,6 @@ class Conformist::HashStructTest < Minitest::Test
     refute_equal hash1, hash3
   end
 
-  def test_merge
-    hash1 = HashStruct.new
-    hash2 = hash1.merge :a => 1
-    refute_equal hash1.object_id, hash2.object_id
-    refute_equal 1, hash1[:a]
-    assert_equal 1, hash2[:a]
-  end
-
   def test_readers_with_method_missing
     hash = HashStruct.new :a => 1, :c_d => 1
     assert_equal 1, hash.a


### PR DESCRIPTION
Processing large amount of columns is very expensive when building `HashStruct`
object over and over again.

This commit removes the need of `HashStruct#merge` and constructs a `HashStruct`
only once.

This also improves performance.

