### PR TITLE
Pass context object to preprocessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ column :first_name, 0 do |value|
 end
 ```
 
+It's also possible to provide a context object that is made available during preprocessing.
+
+``` ruby
+citizen = Conformist.new do
+  column :name, 0, 1 do |values, context|
+    (context[:upcase?] ? values.map(&:upcase) : values) * ' '
+  end
+end
+
+citizen.conform [['tate', 'johnson']], context: {upcase?: true}
+```
+
 ### Virtual Columns
 
 Virtual columns are not sourced from input. Omit the index to create a virtual column. Like real columns, virtual columns are included in the conformed output.

--- a/lib/conformist/builder.rb
+++ b/lib/conformist/builder.rb
@@ -1,9 +1,9 @@
 module Conformist
   class Builder
-    def self.call schema, enumerable
+    def self.call schema, enumerable, context = nil
       columns = schema.columns
       hash = columns.each_with_object({}) do |column, hash|
-        hash[column.name] = column.values_in(enumerable)
+        hash[column.name] = column.values_in(enumerable, context)
       end
       HashStruct.new hash
     end

--- a/lib/conformist/column.rb
+++ b/lib/conformist/column.rb
@@ -21,7 +21,7 @@ module Conformist
       end
     end
 
-    def values_in enumerable
+    def values_in enumerable, context = nil
       enumerable = Array(enumerable)
 
       values = Array(indexes).map do |index|
@@ -35,7 +35,11 @@ module Conformist
       end
       values = values.first if values.size == 1
       if preprocessor
-        preprocessor.call values
+        if preprocessor.arity == 1
+          preprocessor.call values
+        else
+          preprocessor.call values, context
+        end
       else
         values
       end

--- a/lib/conformist/schema.rb
+++ b/lib/conformist/schema.rb
@@ -53,6 +53,7 @@ module Conformist
 
       def conform enumerables, options = {}
         options = options.dup
+        context = options.delete(:context)
 
         Enumerator.new do |yielder|
           enumerables.each do |enumerable|
@@ -61,7 +62,7 @@ module Conformist
               next
             end
 
-            yielder.yield builder.call(self, enumerable)
+            yielder.yield builder.call(self, enumerable, context)
           end
         end
       end

--- a/test/unit/conformist/builder_test.rb
+++ b/test/unit/conformist/builder_test.rb
@@ -4,9 +4,9 @@ class Conformist::BuilderTest < Minitest::Test
   def test_call
     column = Minitest::Mock.new
     column.expect :name, :a
-    column.expect :values_in, [1], [Array]
+    column.expect :values_in, [1], [Array, Hash]
     definition = Minitest::Mock.new
     definition.expect :columns, [column]
-    assert_equal HashStruct.new({:a => [1]}), Builder.call(definition, [])
+    assert_equal HashStruct.new({:a => [1]}), Builder.call(definition, [], {})
   end
 end

--- a/test/unit/conformist/column_test.rb
+++ b/test/unit/conformist/column_test.rb
@@ -50,4 +50,16 @@ class Conformist::ColumnTest < Minitest::Test
     column = Column.new :foo, 0
     assert_nil column.values_in([])
   end
+
+  def test_passes_context
+    context = {'a' => 'b'}
+    column = Column.new(:foo, 0) { |_, ctx| ctx }
+    assert_equal context, column.values_in([], context)
+  end
+
+  def test_respects_preprocessor_arity
+    context = {'a' => 'b'}
+    column = Column.new(:foo, 0, &lambda { |values| })
+    column.values_in([], context)
+  end
 end

--- a/test/unit/conformist/schema_test.rb
+++ b/test/unit/conformist/schema_test.rb
@@ -26,7 +26,7 @@ class Conformist::SchemaTest < Minitest::Test
     definition = Class.new { extend Schema }
     definition.builder = Object
     assert_equal Object, definition.builder
-  end  
+  end
 
   def test_columns_reader
     assert_empty Class.new { extend Schema }.columns
@@ -66,7 +66,7 @@ class Conformist::SchemaTest < Minitest::Test
 
   def test_conform_calls_builders_call_method
     definition = Class.new { extend Schema }
-    definition.builder = lambda { |definition, value| value }
+    definition.builder = lambda { |definition, value, context| value }
     assert_equal [2, 4], definition.conform([1, 2]).map { |value| value * 2 }
   end
 


### PR DESCRIPTION
ATM, if one wants to access a variable with limited scope inside a
preprocessor, the only way to do that is by creating anonymous schemas
on-the-fly and take advantage from the fact that ruby blocks act as
closures. Example:

```ruby
def create_schema(offset)
  Conformist.new do
    column :numeric_value do |value|
      offset + value.to_i
    end
  end
end
```

This change allows developers to pass a context object (typically an hash, but
I'm not enforcing it) to the preprocessors, without the need to continuously
create anonymous schemas. Example:

```ruby
SCHEMA =
  Conformist.new do
    column :numeric_value do |value, context|
      context[:offset].to_i + value.to_i
    end
  end

SCHEMA.conform(something, context: {offset: 5})
```